### PR TITLE
remove references to freenode, decide what to do

### DIFF
--- a/404.html
+++ b/404.html
@@ -32,8 +32,6 @@
 	}
 	</style>
 	<script>
-		console.log('#oslohackerspace @ chat.freenode.net for a 200')
-
 		// 404
 		let str = document.title, i = 0, len = 42 + 1, x, d
 		const pool = [4,0]

--- a/index.en.html
+++ b/index.en.html
@@ -89,8 +89,6 @@
         Event list is populated with JavaScript from <a href="https://www.meetup.com/hackeriet/events/calendar/">meetup.com/hackeriet</a>. Noscript clients should go there directly.
       </div>
     </noscript>
-    <h2>Chat</h2>
-    <p>Unsurprisingly, much of Hackeriet's activities happen in cyberspace. Join our chat on IRC #oslohackerspace on Freenode. </p>
     <h2>Newsletter</h2>
     Subscribe to our newsletter for the (very) occasional update on the goings-on at Hackeriet:
     <!-- Begin MailChimp Signup Form -->

--- a/index.no.html
+++ b/index.no.html
@@ -103,9 +103,6 @@
 
 
 
-    <h2>Chat</h2>
-    <p>Mye av aktiviteten til Hackeriet skjer, ikke overaskende, i kyberrommet. Du kan bli med gjennom IRC #oslohackerspace på Freenode.</p>
-
     <h2>Nyhetsbrev</h2>
     <p>
       Meld deg på epostlista vår for et sporadisk nyhetsbrev om hva som skjer på Hackeriet:


### PR DESCRIPTION
Selv har jeg ikke lyst til å være på Freenode lenger, og min mening er at vi ikke burde sende folk dit fra hjemmesiden vår.

Disse alternativene stikker seg ut:

  0. Bli værende på Freenode

  1. Flytte til en annen IRC server (libera, hackint, autistici, etc.)

  2. Flytte til matrix

  3. Flytte til noe proprietært som Slack eller Discord

Jeg synes at vi skal flytte til libera. Hva synes dere?
