### PR TITLE
Hook open/close notice on the website to CO2 levels instead of a button

### DIFF
--- a/js/hackeriet.js
+++ b/js/hackeriet.js
@@ -100,7 +100,7 @@ function update_door_CO2() {
             }
         }
     }
-    door.send();
+    door_co2.send();
 }
 
 function messageUpdate(k,v) {

--- a/js/hackeriet.js
+++ b/js/hackeriet.js
@@ -86,6 +86,23 @@ function update_door() {
     door.send();
 }
 
+
+function update_door_CO2() {
+    var door_co2 = new XMLHttpRequest();
+    door_co2.open('GET', 'http://aleksei.hackeriet.no/door.json', true);
+    door_co2.onload = function(){
+        if(this.status >= 200 && this.status < 400) {
+            var data = JSON.parse(this.response);
+            if (data.status === "OPEN") {
+                document.getElementById("doorstatus").innerHTML = _hackeriet.openText;
+            } else {
+                document.getElementById("doorstatus").innerHTML = _hackeriet.closedText;
+            }
+        }
+    }
+    door.send();
+}
+
 function messageUpdate(k,v) {
     var elm = _hackeriet.message_elms[k];
     if (!elm) {

--- a/js/hackeriet.js
+++ b/js/hackeriet.js
@@ -89,7 +89,7 @@ function update_door() {
 
 function update_door_CO2() {
     var door_co2 = new XMLHttpRequest();
-    door_co2.open('GET', 'http://aleksei.hackeriet.no/door.json', true);
+    door_co2.open('GET', 'https://aleksei.hackeriet.no/door.json', true);
     door_co2.onload = function(){
         if(this.status >= 200 && this.status < 400) {
             var data = JSON.parse(this.response);


### PR DESCRIPTION
I set up a service on aleksei.hackeriet.no which updates a .json file based on CO2 level in the hackerspace. If over 1000 - someone is there, if below - probably no one is there. Rationale: false positives which happened with the button (I came a couple of times when it was said on the website there was someone in the hackerspace and there was no one). I'll leave it up to you to decide whether you want to use it in addition to, or in combination with, a button.